### PR TITLE
Fixes: Social login crash

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/users/adapter.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/users/adapter.py
@@ -10,5 +10,5 @@ class AccountAdapter(DefaultAccountAdapter):
 
 
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
-    def is_open_for_signup(self, request):
+    def is_open_for_signup(self, request, sociallogin):
         return getattr(settings, 'ACCOUNT_ALLOW_REGISTRATION', True)


### PR DESCRIPTION
`is_open_for_signup` takes exactly 3 parameters for SocialAccountAdapter. Please see https://github.com/pennersr/django-allauth/blob/0bebf27cdfe0023325407553f8dc550d5c794bbf/allauth/socialaccount/adapter.py#L156
